### PR TITLE
removed redirects file

### DIFF
--- a/website/public/_redirects
+++ b/website/public/_redirects
@@ -1,2 +1,0 @@
-# Repo link
-https://repo.ehs-service.org https://github.com/eastlakehs/community-service-tracker 301!


### PR DESCRIPTION
I couldn't figure out why the repo subdomain redirect wasn't working to the this repo so I swapped the dns name servers from netlify dns to google dns because it works in google dns the way I want it to for sure. Don't merge until repo.ehs-service.org redirects to this page and ehs-service.org redirects to the site. 