### PR TITLE
eslint warnings v3

### DIFF
--- a/website/src/AppRouter.tsx
+++ b/website/src/AppRouter.tsx
@@ -25,8 +25,6 @@ import { useIsSignedIn } from "./Firebase/linkAuth/useIsSignedIn";
 import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 
-import { useSelector } from "react-redux";
-
 // Report downloading
 import { ReportPage } from "./Components/Reports/reportPage";
 


### PR DESCRIPTION
```
./src/AppRouter.tsx
  Line 28:10:  'useSelector' is defined but never used  @typescript-eslint/no-unused-vars
```