### PR TITLE
eslint warnings v4

### DIFF
--- a/website/src/Firebase/linkAuth/useIsSignedIn.ts
+++ b/website/src/Firebase/linkAuth/useIsSignedIn.ts
@@ -61,7 +61,7 @@ const useIsSignedIn = () => {
     });
     // detach the listener
     return unsubscribe;
-  }, []);
+  }, [dispatch]);
   return localSignedInState; 
 };
 


### PR DESCRIPTION
This dosn't really do anything (dispatch shouldn't change) but just to get the dumb eslint to not give warnings
```
./src/Firebase/linkAuth/useIsSignedIn.ts
  Line 64:6:  React Hook useEffect has a missing dependency: 'dispatch'. Either include it or remove the dependency array  react-hooks/exhaustive-deps
```