### PR TITLE
add tighter restrictions for the graduation year, fix #161 

### DIFF
--- a/website/src/components/validation/validation.test.ts
+++ b/website/src/components/validation/validation.test.ts
@@ -37,18 +37,40 @@ test("Running Validation Tests for VALIDATE_free_form", () => {
   ).toBe(false);
 });
 
-test("Running Validation Tests for VALIDATE_graduation", () => {
-  expect(VALIDATE_graduation("2021").validate).toBe(true);
-  expect(VALIDATE_graduation("2022").validate).toBe(true);
-  expect(VALIDATE_graduation("2023").validate).toBe(true);
-  expect(VALIDATE_graduation("2099").validate).toBe(true);
+//This function is here to avoid hard coded years in the tests, by returning the current year plus a specified number of years as a string
+//Variable declared outside function to avoid it being re-declared every test
+let year = new Date().getFullYear();
+function thisYearPlus(years: number): string {
+  year += years;
+  return year.toString();
+}
 
+test("Running Validation Tests for VALIDATE_graduation", () => {
+  //Tests expected graduation years
+  expect(VALIDATE_graduation(thisYearPlus(0)).validate).toBe(true);
+  expect(VALIDATE_graduation(thisYearPlus(1)).validate).toBe(true);
+  expect(VALIDATE_graduation(thisYearPlus(2)).validate).toBe(true);
+  expect(VALIDATE_graduation(thisYearPlus(5)).validate).toBe(true);
+
+  //Tests graduation years slightly around the limit
+  expect(VALIDATE_graduation(thisYearPlus(-1)).validate).toBe(false);
+  expect(VALIDATE_graduation(thisYearPlus(6)).validate).toBe(false);
+  expect(VALIDATE_graduation(thisYearPlus(7)).validate).toBe(false);
+  expect(VALIDATE_graduation(thisYearPlus(10)).validate).toBe(false);
+  expect(VALIDATE_graduation(thisYearPlus(20)).validate).toBe(false);
+
+  //Tests bonkers years that should never be valid
   expect(VALIDATE_graduation("").validate).toBe(false);
   expect(VALIDATE_graduation(" ").validate).toBe(false);
   expect(VALIDATE_graduation("          ").validate).toBe(false);
   expect(VALIDATE_graduation("a").validate).toBe(false);
   expect(VALIDATE_graduation("1800").validate).toBe(false);
+  expect(VALIDATE_graduation(thisYearPlus(-6000)).validate).toBe(false);
   expect(VALIDATE_graduation("0000").validate).toBe(false);
-  expect(VALIDATE_graduation("2100").validate).toBe(false);
+  expect(VALIDATE_graduation(thisYearPlus(100)).validate).toBe(false);
+  expect(VALIDATE_graduation(thisYearPlus(50)).validate).toBe(false);
+  expect(VALIDATE_graduation(thisYearPlus(800)).validate).toBe(false);
+  expect(VALIDATE_graduation(thisYearPlus(99999)).validate).toBe(false);
   expect(VALIDATE_graduation("20aa").validate).toBe(false);
+  expect(VALIDATE_graduation(":) :(").validate).toBe(false);
 });

--- a/website/src/components/validation/validation.test.ts
+++ b/website/src/components/validation/validation.test.ts
@@ -38,9 +38,8 @@ test("Running Validation Tests for VALIDATE_free_form", () => {
 });
 
 //This function is here to avoid hard coded years in the tests, by returning the current year plus a specified number of years as a string
-//Variable declared outside function to avoid it being re-declared every test
-let year = new Date().getFullYear();
 function thisYearPlus(years: number): string {
+  let year = new Date().getFullYear();
   year += years;
   return year.toString();
 }
@@ -50,6 +49,8 @@ test("Running Validation Tests for VALIDATE_graduation", () => {
   expect(VALIDATE_graduation(thisYearPlus(0)).validate).toBe(true);
   expect(VALIDATE_graduation(thisYearPlus(1)).validate).toBe(true);
   expect(VALIDATE_graduation(thisYearPlus(2)).validate).toBe(true);
+  expect(VALIDATE_graduation(thisYearPlus(3)).validate).toBe(true);
+  expect(VALIDATE_graduation(thisYearPlus(4)).validate).toBe(true);
   expect(VALIDATE_graduation(thisYearPlus(5)).validate).toBe(true);
 
   //Tests graduation years slightly around the limit

--- a/website/src/components/validation/validation.test.ts
+++ b/website/src/components/validation/validation.test.ts
@@ -62,6 +62,8 @@ test("Running Validation Tests for VALIDATE_graduation", () => {
 
   //Tests bonkers years that should never be valid
   expect(VALIDATE_graduation("").validate).toBe(false);
+  expect(VALIDATE_graduation(NaN).validate).toBe(false);
+  expect(VALIDATE_graduation(2021.24).validate).toBe(false); //floating point
   expect(VALIDATE_graduation(" ").validate).toBe(false);
   expect(VALIDATE_graduation("          ").validate).toBe(false);
   expect(VALIDATE_graduation("a").validate).toBe(false);

--- a/website/src/components/validation/validation.ts
+++ b/website/src/components/validation/validation.ts
@@ -39,15 +39,15 @@ const VALIDATE_graduation = (text: string): ValidationMessage => {
   let thisyear = new Date().getFullYear();
   //This grabs each number in the string into an array
   let matches = text.match(/(\d+)/);
-  if(matches) {
+  if (matches) {
     //If this is true, the extracted number is a different length than the string, meaning there's at least one character not part of the number in the string
-    if(matches[0].length !== text.length) {
+    if (matches[0].length !== text.length) {
       return { validate: false, message: "Invalid Year" };
     }
     //This grabs the actual number from the string
     let num: number = parseInt(matches[0]);
     //If the year submitted is either this year, or less than or equal to 5 years from now, it's valid
-    if(num >= thisyear && num <= thisyear + 5) {
+    if (num >= thisyear && num <= thisyear + 5) {
       return { validate: true, message: "" };
     }
   }

--- a/website/src/components/validation/validation.ts
+++ b/website/src/components/validation/validation.ts
@@ -36,11 +36,23 @@ const VALIDATE_free_form = (text?: string): ValidationMessage => {
 };
 
 const VALIDATE_graduation = (text: string): ValidationMessage => {
-  const re = new RegExp("^(20)\\d\\d$");
-  if (!re.test(text)) {
-    return { validate: false, message: "Invalid Year" };
+  let thisyear = new Date().getFullYear();
+  //This grabs each number in the string into an array
+  let matches = text.match(/(\d+)/);
+  if(matches) {
+    //If this is true, the extracted number is a different length than the string, meaning there's at least one character not part of the number in the string
+    if(matches[0].length !== text.length) {
+      return { validate: false, message: "Invalid Year" };
+    }
+    //This grabs the actual number from the string
+    let num: number = parseInt(matches[0]);
+    //If the year submitted is either this year, or less than or equal to 5 years from now, it's valid
+    if(num >= thisyear && num <= thisyear + 5) {
+      return { validate: true, message: "" };
+    }
   }
-  return { validate: true, message: "" };
+  //If all else fails, the year is invalid
+  return { validate: false, message: "Invalid Year" };
 };
 
 export { VALIDATE_hours, VALIDATE_free_form, VALIDATE_graduation };

--- a/website/src/components/validation/validation.ts
+++ b/website/src/components/validation/validation.ts
@@ -36,19 +36,25 @@ const VALIDATE_free_form = (text?: string): ValidationMessage => {
 };
 
 const VALIDATE_graduation = (text: string): ValidationMessage => {
-  let thisyear = new Date().getFullYear();
+  const thisyear: number = new Date().getFullYear();
   //This grabs each number in the string into an array
-  let matches = text.match(/(\d+)/);
+  const matches = text.match(/(\d+)/);
   if (matches) {
     //If this is true, the extracted number is a different length than the string, meaning there's at least one character not part of the number in the string
     if (matches[0].length !== text.length) {
       return { validate: false, message: "Invalid Year" };
     }
     //This grabs the actual number from the string
-    let num: number = parseInt(matches[0]);
+    const num: number = parseInt(matches[0]);
     //If the year submitted is either this year, or less than or equal to 5 years from now, it's valid
     if (num >= thisyear && num <= thisyear + 5) {
       return { validate: true, message: "" };
+    } else {
+      return {
+        validate: false,
+        message:
+          "Year should be between " + thisyear + " and " + (thisyear + 5),
+      };
     }
   }
   //If all else fails, the year is invalid

--- a/website/src/components/validation/validation.ts
+++ b/website/src/components/validation/validation.ts
@@ -37,28 +37,17 @@ const VALIDATE_free_form = (text?: string): ValidationMessage => {
 
 const VALIDATE_graduation = (text: string): ValidationMessage => {
   const thisyear: number = new Date().getFullYear();
-  //This grabs each number in the string into an array
-  const matches = text.match(/(\d+)/);
-  if (matches) {
-    //If this is true, the extracted number is a different length than the string, meaning there's at least one character not part of the number in the string
-    if (matches[0].length !== text.length) {
-      return { validate: false, message: "Invalid Year" };
-    }
-    //This grabs the actual number from the string
-    const num: number = parseInt(matches[0]);
-    //If the year submitted is either this year, or less than or equal to 5 years from now, it's valid
-    if (num >= thisyear && num <= thisyear + 5) {
-      return { validate: true, message: "" };
-    } else {
-      return {
-        validate: false,
-        message:
-          "Year should be between " + thisyear + " and " + (thisyear + 5),
-      };
-    }
+  const gradYear: number = Number(text);
+  if (!Number.isInteger(gradYear)) {
+    return { validate: false, message: "Invalid Year" };
+  } else if (gradYear >= thisyear && gradYear <= thisyear + 5) {
+    return { validate: true, message: "" };
+  } else {
+    return {
+      validate: false,
+      message: `Year should be between ${thisyear} and ${thisyear + 5}`,
+    };
   }
-  //If all else fails, the year is invalid
-  return { validate: false, message: "Invalid Year" };
 };
 
 export { VALIDATE_hours, VALIDATE_free_form, VALIDATE_graduation };


### PR DESCRIPTION
This PR:
Edits the tests to be strict about which years are allowed for graduation
Edits the tests to dynamically update depending on the current year
Edits the validation to validate the graduation year against the new 5 year limit