### PR TITLE
Add a workflow to automatically update the copyright year on the license file

### DIFF
--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -7,7 +7,6 @@ on:
 
   workflow_dispatch:
 
-  push:
   pull_request:
 
 jobs:

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -22,7 +22,8 @@ jobs:
       #This uses sed to change the year
       - name: Edit the license file
         run: |
-          python ./actions/license/update.py
+          cd ./actions/license
+          python update.py
 
       - name: Commit the changes
         run: |

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -23,13 +23,10 @@ jobs:
           python update.py
 
       - name: Commit the changes
-        #This makes sure the workflow doesn't fail if there's nothing to be committed
-        continue-on-error: true
         run: |
           git config --global user.email "<>"
           git config --global user.name "Github Actions Bot"
           git add .
-          git commit -m 'Update license year'
+          git commit -m 'Update license year' || true # pass is there is nothing to commit
           git push
-
 

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -25,6 +25,8 @@ jobs:
           python update.py
 
       - name: Commit the changes
+        #This makes sure the workflow doesn't fail if there's nothing to be committed
+        continue-on-error: true
         run: |
           git config --global user.email "<>"
           git config --global user.name "Github Actions Bot"

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -7,7 +7,7 @@ on:
 
   workflow_dispatch:
 
-  pull_request:
+  push:
 
 jobs:
   update:

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -7,8 +7,6 @@ on:
 
   workflow_dispatch:
 
-  push:
-
 jobs:
   update:
     runs-on: ubuntu-latest

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -1,0 +1,32 @@
+name: Update License
+
+
+on:
+  schedule:
+    - cron: '0 0 1 * *'
+
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+
+    steps:
+      # Checks-out repo
+      - uses: actions/checkout@v2
+
+      #This uses sed to change the year
+      - name: Edit the license file
+        run: |
+          python ./actions/license/update.py
+
+      - name: Commit the changes
+        run: |
+          git config --global user.email "<>"
+          git config --global user.name "Github Actions Bot"
+          git add .
+          git commit -m 'Update license year'
+          git push
+
+

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -7,6 +7,9 @@ on:
 
   workflow_dispatch:
 
+  push:
+  pull_request:
+
 jobs:
   update:
     runs-on: ubuntu-latest

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Eastlake High School
+Copyright (c) 2021 Eastlake High School
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Eastlake High School
+Copyright (c) 2020 Eastlake High School
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/actions/license/update.py
+++ b/actions/license/update.py
@@ -1,12 +1,17 @@
 from datetime import datetime
 import re
 
+# get today's date
 today = datetime.today()
 
 with open("../../LICENSE", "r+") as f:
-    old = f.read() # read everything in the file
+    # read everything in the file and store
+    old = f.read() 
+    # delete
     f.truncate(0)
+    # go to start
     f.seek(0)
+    # rewrite by subbing in any year related numbers with today's year
     f.write(re.sub(r"([1-3][0-9]{3})", str(today.year), old))
 
 print("Completed!")

--- a/actions/license/update.py
+++ b/actions/license/update.py
@@ -1,0 +1,14 @@
+import sys
+import fileinput
+from datetime import datetime
+import re
+
+today = datetime.today()
+
+with open("../../LICENSE", "r+") as f:
+    old = f.read() # read everything in the file
+    f.truncate(0)
+    f.seek(0)
+    f.write(re.sub(r"([1-3][0-9]{3})", str(today.year), old))
+
+print("Completed!")

--- a/actions/license/update.py
+++ b/actions/license/update.py
@@ -1,5 +1,3 @@
-import sys
-import fileinput
 from datetime import datetime
 import re
 


### PR DESCRIPTION
This PR:
Adds a python script to update the license copyright year (Thanks @Zjjc123 !)
Adds a workflow scheduled to run on the first day of every month to update the year. It also has the ability to be manually run (I've also added it to run on a PR and/or on push for testing, once I've tested it I'll remove that trigger and mark the PR ready to merge)
