### PR TITLE
Make security rules more strict

### DIFF
--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -3,28 +3,37 @@ service cloud.firestore {
   match /databases/{database}/documents {
     
     function emailMatchesDocument (_document) {
-      return (request.auth != null && request.auth.token.email.lower() == _document);
+      return (request.auth.token.email.lower() == _document);
     }
     
     // only accept requests from school emails to prevent spam
     function emailIsValid (_email) {
       return (request.auth.token.email.matches('.*@lwsd.org') || request.auth.token.email.matches('.*@bellevuecollege.edu'));
     }
+
+    // allow only email/password based auth 
+    // require email verification
+    // if a user uses email-link-auth first, firebase prevents setting a password for the account (tested this myself), requiring an email-based password reset
+    function isAuthenticatedProperly () {
+      let isAuthed = request.auth != null && request.auth.token != null && request.auth.token.email != null; 
+      let isVerified = request.auth.token.email_verified; 
+      let isPasswordAuth = request.auth.token.firebase.sign_in_provider == "password";
+      return (isAuthed && isVerified && isPasswordAuth);
+    }
+
+    function isAdmin () {
+      return (request.auth.token.email.matches('eastlakekey@gmail.com') || request.auth.token.email.matches('daniel@sudzilouski.com'));
+    }
     
     // users are free to read and edit their own documents 
     // as long as the document matches their authenticated email
     match /users/{email}/{document=**} { 
-      allow read, write: if emailMatchesDocument(email) && emailIsValid(email); 
+      allow read, write: if isAuthenticatedProperly() &&  emailIsValid(email) && emailMatchesDocument(email);
     }
     
-    // anyone can download the reports that contain hour summaries and awards
-    match /reports/{document=**} { 
-      allow read;
-    }
-    
-    // admin users that can impersonate any user to view/edit data
+    // admin users have full access to database
     match /{path=**} {
-    	allow read, write: if request.auth.token.email.matches('eastlakekey@gmail.com') || request.auth.token.email.matches('daniel@sudzilouski.com');
+    	allow read, write: if isAuthenticatedProperly() && isAdmin();
     }
     
   } 

--- a/firebase/tests/firestore.test.ts
+++ b/firebase/tests/firestore.test.ts
@@ -185,13 +185,13 @@ describe("admins should be able to do anything", () => {
     expect(await firebase.assertSucceeds(randomDoc3.get()));
   });
 
-  it("writing to anything as admin)", async () => {
+  it("writing to anything as admin", async () => {
     expect(await firebase.assertSucceeds(randomDoc1.set({})));
     expect(await firebase.assertSucceeds(randomDoc2.set({})));
     expect(await firebase.assertSucceeds(randomDoc3.set({})));
   });
 
-  it("deleting anything as admin)", async () => {
+  it("deleting anything as admin", async () => {
     expect(await firebase.assertSucceeds(randomDoc1.delete()));
     expect(await firebase.assertSucceeds(randomDoc2.delete()));
     expect(await firebase.assertSucceeds(randomDoc3.delete()));

--- a/firebase/tests/firestore.test.ts
+++ b/firebase/tests/firestore.test.ts
@@ -1,7 +1,11 @@
-// root
-import * as firebase from "@firebase/testing";
+/**
+ *  About: this file contains security unit testing in order to ensure that our app is secured from un-authorized outside access
+ */
 
-const initDB = (auth: { uid: string; email: string }) => {
+import * as firebase from "@firebase/testing";
+import { AppOptions } from "@firebase/testing/dist/src/api";
+
+const initDB = (auth: AppOptions["auth"]) => {
   const app = firebase.initializeTestApp({
     projectId: "community-ser",
     auth: auth,
@@ -9,9 +13,34 @@ const initDB = (auth: { uid: string; email: string }) => {
   return app.firestore();
 };
 
+const tokenValid = {
+  firebase: {
+    sign_in_provider: "password",
+  },
+  email_verified: true,
+};
+
+const tokenNotVerified = {
+  firebase: {
+    sign_in_provider: "password",
+  },
+  email_verified: false,
+};
+
+const tokenNotPasswordAuth = {
+  firebase: {
+    sign_in_provider: "something else",
+  },
+  email_verified: true,
+};
+
 describe("non-user docs should reject", () => {
   // signed in as student-a@lwsd.org
-  const db = initDB({ uid: "test-student", email: "student-a@lwsd.org" });
+  const db = initDB({
+    uid: "test-student",
+    email: "student-a@lwsd.org",
+    ...tokenValid,
+  });
 
   // signed in as student-a, reading to student-b should fail
   it("reading to student-b as student-a", async () => {
@@ -32,30 +61,78 @@ describe("non-user docs should reject", () => {
 
 describe("own docs should resolve", () => {
   // signed in as student-a@lwsd.org
-  const db = initDB({ uid: "test-student", email: "student-a@lwsd.org" });
+  const db = initDB({
+    uid: "test-student",
+    email: "student-a@lwsd.org",
+    ...tokenValid,
+  });
 
-  // signed in as student-a, reading to student-b should fail
+  // signed in as student-a, reading to student-a should pass
   it("reading to student-a as student-a", async () => {
     const nonUserDoc = db.collection("users").doc("student-a@lwsd.org");
     expect(await firebase.assertSucceeds(nonUserDoc.get()));
   });
-  // signed in as student-a, writing to student-b should fail
+  // signed in as student-a, writing to student-a should pass
   it("writing to student-a as student-a", async () => {
     const nonUserDoc = db.collection("users").doc("student-a@lwsd.org");
     expect(await firebase.assertSucceeds(nonUserDoc.set({})));
   });
 });
 
+describe("own docs not resolve with non-verified email", () => {
+  // signed in as student-a@lwsd.org
+  const db = initDB({
+    uid: "test-student",
+    email: "student-a@lwsd.org",
+    ...tokenNotVerified,
+  });
+
+  // signed in as student-a, reading to student-a should fail with non-verified email
+  it("reading to student-a as student-a", async () => {
+    const nonUserDoc = db.collection("users").doc("student-a@lwsd.org");
+    expect(await firebase.assertFails(nonUserDoc.get()));
+  });
+  // signed in as student-a, writing to student-a should fail with non-verified email
+  it("writing to student-a as student-a", async () => {
+    const nonUserDoc = db.collection("users").doc("student-a@lwsd.org");
+    expect(await firebase.assertFails(nonUserDoc.set({})));
+  });
+});
+
+describe("own docs not resolve with non-password-based auth", () => {
+  // signed in as student-a@lwsd.org
+  const db = initDB({
+    uid: "test-student",
+    email: "student-a@lwsd.org",
+    ...tokenNotPasswordAuth,
+  });
+
+  // signed in as student-a, reading to student-a should fail with non-password-based auth
+  it("reading to student-a as student-a", async () => {
+    const nonUserDoc = db.collection("users").doc("student-a@lwsd.org");
+    expect(await firebase.assertFails(nonUserDoc.get()));
+  });
+  // signed in as student-a, writing to student-a should fail with non-password-based auth
+  it("writing to student-a as student-a", async () => {
+    const nonUserDoc = db.collection("users").doc("student-a@lwsd.org");
+    expect(await firebase.assertFails(nonUserDoc.set({})));
+  });
+});
+
 describe("non valid school email docs should reject", () => {
   // signed in as student-a@lwsd.org
-  const db = initDB({ uid: "test-student", email: "student-a@domain.org" });
+  const db = initDB({
+    uid: "test-student",
+    email: "student-a@domain.org",
+    ...tokenValid,
+  });
 
   // non valid school email read should reject
   it("reading to student-a as student-a (@domain.org)", async () => {
     const nonUserDoc = db.collection("users").doc("student-a@domain.org");
     expect(await firebase.assertFails(nonUserDoc.get()));
   });
-  // non lwvalid school email write should reject
+  // non lwsd school email write should reject
   it("writing to student-a as student-a (@domain.org)", async () => {
     const nonUserDoc = db.collection("users").doc("student-a@domain.org");
     expect(await firebase.assertFails(nonUserDoc.set({})));
@@ -67,6 +144,7 @@ describe("bellevue college student emails should pass", () => {
   const db = initDB({
     uid: "test-student",
     email: "student-a@bellevuecollege.edu",
+    ...tokenValid,
   });
 
   // whitelisted non lwsd email read should pass
@@ -82,5 +160,40 @@ describe("bellevue college student emails should pass", () => {
       .collection("users")
       .doc("student-a@bellevuecollege.edu");
     expect(await firebase.assertSucceeds(nonUserDoc.set({})));
+  });
+});
+
+describe("admins should be able to do anything", () => {
+  // signed in as admin (eastlakekey@gmail.com)
+  const db = initDB({
+    uid: "test-student",
+    email: "eastlakekey@gmail.com",
+    ...tokenValid,
+  });
+
+  const randomDoc1 = db.collection("users").doc("dsaklk");
+  const randomDoc2 = db.collection("dsagafdsa").doc("321fdssa");
+  const randomDoc3 = db
+    .collection("ddsadsadsa")
+    .doc("fsakl.dfsa")
+    .collection("dsak.k.dfsa")
+    .doc("dsads.kvk");
+
+  it("reading to anything as admin", async () => {
+    expect(await firebase.assertSucceeds(randomDoc1.get()));
+    expect(await firebase.assertSucceeds(randomDoc2.get()));
+    expect(await firebase.assertSucceeds(randomDoc3.get()));
+  });
+
+  it("writing to anything as admin)", async () => {
+    expect(await firebase.assertSucceeds(randomDoc1.set({})));
+    expect(await firebase.assertSucceeds(randomDoc2.set({})));
+    expect(await firebase.assertSucceeds(randomDoc3.set({})));
+  });
+
+  it("deleting anything as admin)", async () => {
+    expect(await firebase.assertSucceeds(randomDoc1.delete()));
+    expect(await firebase.assertSucceeds(randomDoc2.delete()));
+    expect(await firebase.assertSucceeds(randomDoc3.delete()));
   });
 });


### PR DESCRIPTION
Closes #179 

- Requires email to be verified 
- Allows only password-based auth (in case of misconfiguration)
- Removed rule permitting all users to read report summaries (admin only)
- Updated unit tests for more coverage of test cases

Someone check that access still works in prod when this gets merged. 

![image](https://user-images.githubusercontent.com/52898838/118043975-eeb88300-b32a-11eb-8bbb-479d6fdf0b6e.png)
