### PR TITLE
Remove sentry heartbeat

### DIFF
--- a/website/src/errorLogging.ts
+++ b/website/src/errorLogging.ts
@@ -13,6 +13,4 @@ export const initErrorLogging = () => {
     // We recommend adjusting this value in production
     tracesSampleRate: 1.0,
   });
-  // heart beat to know if sentry is working
-  Sentry.captureException("[NOT AN ERROR] Client Loaded Site");
 };


### PR DESCRIPTION
No longer needed (tested that it works at recording traces) and it clutters up the trace logs for actual traces. 