### PR TITLE
Add notice to table when there is no profile data

### DIFF
--- a/website/src/components/login/loginForm.tsx
+++ b/website/src/components/login/loginForm.tsx
@@ -79,12 +79,12 @@ const LoginForm = () => {
       if (signedInstate.admin) {
         history.replace("/admin");
       } else {
-        if(profileState.firstName === "") {
+        if (profileState.firstName === "") {
           history.replace("/profile");
         } else {
           history.replace("/table");
         }
-      } 
+      }
     }
   });
   return (

--- a/website/src/components/login/loginForm.tsx
+++ b/website/src/components/login/loginForm.tsx
@@ -5,7 +5,6 @@ import { isAdmin } from "../../constants/isAdmin";
 import { useHistory } from "react-router-dom";
 import { selectSignedInState } from "../../redux/signedInSlice";
 import { useSelector } from "react-redux";
-import { selectProfileState } from "../../redux/profileScreenSlice";
 type emailState =
   | "base"
   | "email-send-failed"
@@ -73,17 +72,13 @@ const LoginForm = () => {
   const history = useHistory();
   const [emailState, setEmailState] = useState<emailState>("base");
   const [emailInput, setEmailInput] = useState("");
-  const profileState = useSelector(selectProfileState);
+
   useEffect(() => {
     if (signedInstate.signedIn) {
       if (signedInstate.admin) {
         history.replace("/admin");
       } else {
-        if (profileState.firstName === "") {
-          history.replace("/profile");
-        } else {
-          history.replace("/table");
-        }
+        history.replace("/table");        
       }
     }
   });

--- a/website/src/components/login/loginForm.tsx
+++ b/website/src/components/login/loginForm.tsx
@@ -5,6 +5,7 @@ import { isAdmin } from "../../constants/isAdmin";
 import { useHistory } from "react-router-dom";
 import { selectSignedInState } from "../../redux/signedInSlice";
 import { useSelector } from "react-redux";
+import { selectProfileState } from "../../redux/profileScreenSlice";
 type emailState =
   | "base"
   | "email-send-failed"
@@ -78,8 +79,13 @@ const LoginForm = () => {
       if (signedInstate.admin) {
         history.replace("/admin");
       } else {
-        history.replace("/profile");
-      }
+        const ProfileState = selectProfileState();
+        if(ProfileState.firstName == null || ProfileState.graduationYear == null || ProfileState.lastName == null) {
+          history.replace("/profile");
+        } else {
+          history.replace("/table");
+        }
+      } 
     }
   });
   return (

--- a/website/src/components/login/loginForm.tsx
+++ b/website/src/components/login/loginForm.tsx
@@ -78,7 +78,7 @@ const LoginForm = () => {
       if (signedInstate.admin) {
         history.replace("/admin");
       } else {
-        history.replace("/table");        
+        history.replace("/table");
       }
     }
   });

--- a/website/src/components/login/loginForm.tsx
+++ b/website/src/components/login/loginForm.tsx
@@ -73,14 +73,13 @@ const LoginForm = () => {
   const history = useHistory();
   const [emailState, setEmailState] = useState<emailState>("base");
   const [emailInput, setEmailInput] = useState("");
-
+  const profileState = useSelector(selectProfileState);
   useEffect(() => {
     if (signedInstate.signedIn) {
       if (signedInstate.admin) {
         history.replace("/admin");
       } else {
-        const ProfileState = selectProfileState();
-        if(ProfileState.firstName == null || ProfileState.graduationYear == null || ProfileState.lastName == null) {
+        if(profileState.firstName === "") {
           history.replace("/profile");
         } else {
           history.replace("/table");

--- a/website/src/components/table/table.tsx
+++ b/website/src/components/table/table.tsx
@@ -4,6 +4,7 @@ import { Day } from "react-modern-calendar-datepicker";
 import { totalizeHours } from "./Totalizer/totalizer";
 import { handleExport } from "./exporter/handleExport";
 import InfoPage from "../info/infoPage";
+import { ISignedInState } from "../../redux/signedInSlice";
 /* Table CSS Credit: https://tailwindcomponents.com/component/table-responsive-with-filters */
 
 const TableHeaderStyle: string =
@@ -11,9 +12,10 @@ const TableHeaderStyle: string =
 
 const CSTable: React.FunctionComponent<{
   data: initialStateType;
+  user: ISignedInState;
   handleEditClick: (entryID: string) => void;
   handleDelete: (entryID: string) => void;
-}> = ({ data, handleEditClick, handleDelete }) => {
+}> = ({ data, user, handleEditClick, handleDelete }) => {
   const generateHeader = () => {
     return data.header.map((header) => {
       return (
@@ -80,6 +82,16 @@ const CSTable: React.FunctionComponent<{
     });
   };
 
+  if (user.userEmail) {
+    return (
+      <InfoPage
+        title="No Profile Data!"
+        message="Click here to update your profile data"
+        link="/profile"
+      />
+    )
+  }
+  
   if (Object.keys(data.data).length === 0) {
     return (
       <InfoPage

--- a/website/src/components/table/table.tsx
+++ b/website/src/components/table/table.tsx
@@ -4,7 +4,7 @@ import { Day } from "react-modern-calendar-datepicker";
 import { totalizeHours } from "./Totalizer/totalizer";
 import { handleExport } from "./exporter/handleExport";
 import InfoPage from "../info/infoPage";
-import { ISignedInState } from "../../redux/signedInSlice";
+import { userProfileData } from "../../firebase/firestore/firestoreData.type";
 /* Table CSS Credit: https://tailwindcomponents.com/component/table-responsive-with-filters */
 
 const TableHeaderStyle: string =
@@ -12,10 +12,10 @@ const TableHeaderStyle: string =
 
 const CSTable: React.FunctionComponent<{
   data: initialStateType;
-  user: ISignedInState;
+  userData: userProfileData;
   handleEditClick: (entryID: string) => void;
   handleDelete: (entryID: string) => void;
-}> = ({ data, user, handleEditClick, handleDelete }) => {
+}> = ({ data, userData, handleEditClick, handleDelete }) => {
   const generateHeader = () => {
     return data.header.map((header) => {
       return (
@@ -82,7 +82,7 @@ const CSTable: React.FunctionComponent<{
     });
   };
 
-  if (user.userEmail) {
+  if (!userData.firstName) {
     return (
       <InfoPage
         title="No Profile Data!"

--- a/website/src/components/table/table.tsx
+++ b/website/src/components/table/table.tsx
@@ -89,9 +89,9 @@ const CSTable: React.FunctionComponent<{
         message="Click here to update your profile data"
         link="/profile"
       />
-    )
+    );
   }
-  
+
   if (Object.keys(data.data).length === 0) {
     return (
       <InfoPage

--- a/website/src/components/table/tableController.tsx
+++ b/website/src/components/table/tableController.tsx
@@ -50,6 +50,7 @@ const TableController: React.FunctionComponent<{}> = () => {
   return (
     <CSTable
       data={data}
+      user={user}
       handleEditClick={navigateToEdit}
       handleDelete={handleDelete}
     />

--- a/website/src/components/table/tableController.tsx
+++ b/website/src/components/table/tableController.tsx
@@ -9,9 +9,11 @@ import { useHistory } from "react-router-dom";
 import { setCurrentEdit } from "../../redux/editScreenSlice";
 import { deleteEntry } from "../../firebase/firestore/deleteEntry";
 import { isAdmin } from "../../constants/isAdmin";
+import { selectProfileState } from "../../redux/profileScreenSlice";
 const TableController: React.FunctionComponent<{}> = () => {
   const data = useSelector(selectUserData);
   const user = useSelector(selectSignedInState);
+  const userProfileData = useSelector(selectProfileState);
 
   const dispatch = useDispatch();
   const history = useHistory();
@@ -50,7 +52,7 @@ const TableController: React.FunctionComponent<{}> = () => {
   return (
     <CSTable
       data={data}
-      user={user}
+      userData={userProfileData}
       handleEditClick={navigateToEdit}
       handleDelete={handleDelete}
     />

--- a/website/src/pages/home.tsx
+++ b/website/src/pages/home.tsx
@@ -8,7 +8,7 @@ import { selectSignedInState } from "../redux/signedInSlice";
 const Home = () => {
   const signedInstate = useSelector(selectSignedInState);
   const history = useHistory();
-  // users that are logged in in should be redirected to hours table or profile page
+  // users that are logged in in should be redirected to profile page
   useEffect(() => {
     if (signedInstate.signedIn) {
       if (signedInstate.admin) {

--- a/website/src/pages/home.tsx
+++ b/website/src/pages/home.tsx
@@ -4,18 +4,24 @@ import Helmet from "../components/header/helmet";
 import { useHistory } from "react-router-dom";
 import { useSelector } from "react-redux";
 import { selectSignedInState } from "../redux/signedInSlice";
+import { selectProfileState } from "../redux/profileScreenSlice";
 
 const Home = () => {
   const signedInstate = useSelector(selectSignedInState);
   const history = useHistory();
-  // users that are logged in in should be redirected to profile page
+  // users that are logged in in should be redirected to hours table or profile page
   useEffect(() => {
     if (signedInstate.signedIn) {
       if (signedInstate.admin) {
         history.replace("/admin");
       } else {
-        history.replace("/profile");
-      }
+        const ProfileState = useSelector(selectProfileState);
+        if(ProfileState.firstName == null || ProfileState.graduationYear == null || ProfileState.lastName == null) {
+          history.replace("/profile");
+        } else {
+          history.replace("/table");
+        }
+      } 
     }
   });
   return (

--- a/website/src/pages/home.tsx
+++ b/website/src/pages/home.tsx
@@ -4,7 +4,6 @@ import Helmet from "../components/header/helmet";
 import { useHistory } from "react-router-dom";
 import { useSelector } from "react-redux";
 import { selectSignedInState } from "../redux/signedInSlice";
-import { selectProfileState } from "../redux/profileScreenSlice";
 
 const Home = () => {
   const signedInstate = useSelector(selectSignedInState);

--- a/website/src/pages/home.tsx
+++ b/website/src/pages/home.tsx
@@ -8,7 +8,6 @@ import { selectProfileState } from "../redux/profileScreenSlice";
 
 const Home = () => {
   const signedInstate = useSelector(selectSignedInState);
-  const profileState = useSelector(selectProfileState);
   const history = useHistory();
   // users that are logged in in should be redirected to hours table or profile page
   useEffect(() => {
@@ -16,15 +15,7 @@ const Home = () => {
       if (signedInstate.admin) {
         history.replace("/admin");
       } else {
-        if (
-          profileState.firstName === "" ||
-          profileState.graduationYear === "" ||
-          profileState.lastName === ""
-        ) {
-          history.replace("/profile");
-        } else {
-          history.replace("/table");
-        }
+        history.replace("/table");
       }
     }
   });

--- a/website/src/pages/home.tsx
+++ b/website/src/pages/home.tsx
@@ -16,12 +16,16 @@ const Home = () => {
       if (signedInstate.admin) {
         history.replace("/admin");
       } else {
-        if(profileState.firstName === "" || profileState.graduationYear === "" || profileState.lastName === "") {
+        if (
+          profileState.firstName === "" ||
+          profileState.graduationYear === "" ||
+          profileState.lastName === ""
+        ) {
           history.replace("/profile");
         } else {
           history.replace("/table");
         }
-      } 
+      }
     }
   });
   return (

--- a/website/src/pages/home.tsx
+++ b/website/src/pages/home.tsx
@@ -8,6 +8,7 @@ import { selectProfileState } from "../redux/profileScreenSlice";
 
 const Home = () => {
   const signedInstate = useSelector(selectSignedInState);
+  const profileState = useSelector(selectProfileState);
   const history = useHistory();
   // users that are logged in in should be redirected to hours table or profile page
   useEffect(() => {
@@ -15,8 +16,7 @@ const Home = () => {
       if (signedInstate.admin) {
         history.replace("/admin");
       } else {
-        const ProfileState = useSelector(selectProfileState);
-        if(ProfileState.firstName == null || ProfileState.graduationYear == null || ProfileState.lastName == null) {
+        if(profileState.firstName === "" || profileState.graduationYear === "" || profileState.lastName === "") {
           history.replace("/profile");
         } else {
           history.replace("/table");


### PR DESCRIPTION
This PR will:
- Resolve eastlakehs/community-service-tracker#190 
- Change it to redirect to the hours table instead of the profile page after login
- Make it so that if the user does not have their profile data, redirect them to the profile page after login

I'm aware formatting is wrong, I'll run prettier before marking this ready for review