### PR TITLE
Update production workflow to use nodejs 14

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -13,6 +13,11 @@ jobs:
     - uses: actions/checkout@v2
       name: Checkout repository
 
+    - uses: actions/setup-node@v2
+      name: Setup NodeJS v14
+      with:
+        node-version: '14'
+
       # Caches the node_modules
     - uses: actions/cache@v2
       name: Cache node_modules

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,11 @@ jobs:
     - uses: actions/checkout@v2
       name: Checkout repository
 
+    - uses: actions/setup-node@v2
+      name: Setup NodeJS v14
+      with:
+        node-version: '14'
+
     # Caches the firebase emulator
     - uses: actions/cache@v2
       name: Cache firebase emulator


### PR DESCRIPTION
## This pull request:
<!-- Add a list of what this pull request adds/fixes -->  

- Updates the production workflow to force it to use NodeJS 14
- Updates the testing workflow to force it to use NodeJS 14

## Context:
<!-- Add any context about the pull request here -->
When pushing some dependancy updates, the workflow to deploy to firebase failed, as the workflow runner by default had nodejs 16. Yarn was expecting version 14. This pull requests adds a setup-node action to force the nodejs version to 14.

## After this PR is merged:

I will go back to the dependabot PRs, including #213 #212 and #211 and re-run the workflows, which will then accurately run the tests with nodejs 14.