### PR TITLE
Add concurrency key to production workflow

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -1,4 +1,6 @@
 name: Production
+#Prevents multiple firebase deploy workflows running at the same time
+#If another run is requested, it will be queued until the running one finishes
 concurrency: firebase_deploy
 
 on:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   deploy:
+    concurrency: firebase_deploy
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -1,4 +1,5 @@
 name: Production
+concurrency: firebase_deploy
 
 on:
   push:
@@ -7,7 +8,6 @@ on:
 
 jobs:
   deploy:
-    concurrency: firebase_deploy
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## This pull request:
<!-- Add a list of what this pull request adds/fixes -->  

- Adds a concurrency key to the production workflow to prevent multiple runs at the same time, which has caused issues 

## Context:
<!-- Add any context about the pull request here -->
Documentation about concurrency: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
I have it set up to queue a new production job and wait if there's an old job running. Since the deploy workflow takes 5 minutes to run, it won't have to wait for long. This will also allow us to merge multiple PRs at the same time and not worry about the workflow breaking.

## Screenshots
<!-- If you have any, add screenshots here -->
From GitHub's documentation:
![image](https://user-images.githubusercontent.com/20461232/171795296-ff380a77-69db-4dca-836d-295b38cd39a2.png)

## Next Steps
After merging this PR, we can then go and merge all the Dependabot PRs at the same time without issue, rather than waiting 5 minutes between each merge.